### PR TITLE
Fix inconsistency between component and top-level making the componen…

### DIFF
--- a/TEST_AREA/hw/hdl/pca9673/hdl/i2c_pio.vhd
+++ b/TEST_AREA/hw/hdl/pca9673/hdl/i2c_pio.vhd
@@ -36,7 +36,7 @@ entity i2c_pio is
         -- PCA9673 signals
         signal pio_int_n   : in    std_logic;
         signal pio_reset_n : out   std_logic;
-        signal scl         : out   std_logic;
+        signal scl         : inout std_logic;
         signal sda         : inout std_logic);
 end entity i2c_pio;
 


### PR DESCRIPTION
…t outputing always '0' for SCL